### PR TITLE
Changes E-mail regex

### DIFF
--- a/210EmailValidation.md
+++ b/210EmailValidation.md
@@ -2,7 +2,7 @@
 
 Remember this regex string?
 
-`r'^[a-zA-Z0-9\.\+_-]+@[a-zA-Z0-9\._-]+\.[a-zA-Z]*$'`
+`r'^[a-zA-Z0-9.+_-]+@[a-zA-Z0-9._-]+\.[a-zA-Z]+$'`
 
 Remember this assignment?
 


### PR DESCRIPTION
The dot and plus didn't need to be escaped; inside a character class (the square braces), those are already treated as the literal characters.  Also, changed the last asterisk to a plus, because I'm pretty sure the E-mail domain can't be empty.
